### PR TITLE
[Feature] TextField

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+input,
+textarea,
+select,
+button {
+  outline: none;
+}
+
 @layer components {
   .display-large {
     @apply text-3xl font-medium leading-10;

--- a/src/shared/lib/focus.ts
+++ b/src/shared/lib/focus.ts
@@ -1,0 +1,29 @@
+import { useRef, useState } from 'react'
+
+export const useFocus = <T extends HTMLElement>() => {
+  const [focused, setFocused] = useState(false)
+
+  const ref = useRef<T>(null)
+
+  const handleElementClick = () => {
+    if (ref.current) {
+      ref.current.focus()
+    }
+  }
+
+  const handleElementFocus = () => {
+    setFocused(true)
+  }
+
+  const handleElementBlur = () => {
+    setFocused(false)
+  }
+
+  return {
+    focused,
+    elementRef: ref,
+    handleElementClick,
+    handleElementFocus,
+    handleElementBlur,
+  }
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,1 +1,3 @@
 export { cn } from './classname'
+export { Slot, createSlot } from './slot'
+export { useFocus } from './focus'

--- a/src/shared/lib/slot/createSlot.ts
+++ b/src/shared/lib/slot/createSlot.ts
@@ -1,0 +1,51 @@
+import { isArray, isUndefined } from 'lodash-es'
+import {
+  ReactNode,
+  Children,
+  isValidElement,
+  Fragment,
+  ReactElement,
+  ReactPortal,
+  JSXElementConstructor,
+} from 'react'
+
+type Child =
+  | ReactPortal
+  | ReactElement<unknown, string | JSXElementConstructor<any>>
+
+type Slots = {
+  [key: string]: ReactNode
+}
+
+export const createSlot = (children: ReactNode, slots: string[]) => {
+  const slotMap: Slots = {}
+
+  const hasSlot = (slot: string) => !isUndefined(slotMap[slot])
+
+  const isFragment = (child: Child) => child.type === Fragment
+
+  const addSlot = (child: ReactNode) => {
+    if (!isValidElement(child)) return
+
+    if (isFragment(child)) {
+      const fragmentChildren = child.props.children
+
+      if (isArray(fragmentChildren)) {
+        child.props.children.forEach((subChild: Child) => addSlot(subChild))
+      } else {
+        addSlot(child.props.children)
+      }
+
+      return
+    }
+
+    const slotName = child.props.name
+    if (slotName && slots.includes(slotName)) {
+      slotMap[slotName] = child.props.children
+    }
+  }
+
+  Children.forEach(children, child => addSlot(child))
+
+  return { slots: slotMap, hasSlot }
+}

--- a/src/shared/lib/slot/index.ts
+++ b/src/shared/lib/slot/index.ts
@@ -1,0 +1,2 @@
+export { Slot } from './slot'
+export { createSlot } from './createSlot'

--- a/src/shared/lib/slot/slot.tsx
+++ b/src/shared/lib/slot/slot.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+
+type Props = {
+  name: string
+  children: ReactNode
+}
+
+export const Slot = ({ children }: Props) => {
+  return <>{children}</>
+}

--- a/src/shared/ui/text-field/index.tsx
+++ b/src/shared/ui/text-field/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react'
 
 import { cn, useFocus } from 'shared/lib'
+import { createSlot } from 'shared/lib'
 import {
   textField,
   input,
@@ -28,6 +29,7 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
       readOnly = false,
       disabled = false,
       maxLength = 255,
+      children,
       autoComplete = 'off',
       onClick,
       onFocus,
@@ -36,6 +38,24 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
     },
     ref,
   ) => {
+    const { slots, hasSlot } = createSlot(children, ['left', 'right'])
+
+    const slotClass = (() => {
+      if (hasSlot('left') && hasSlot('right')) {
+        return 'both'
+      }
+
+      if (hasSlot('left')) {
+        return 'left'
+      }
+
+      if (hasSlot('right')) {
+        return 'right'
+      }
+
+      return null
+    })()
+
     const {
       focused,
       elementRef,
@@ -74,10 +94,15 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
         )}
         onClick={handleClick}
       >
+        {slots?.left && <div className="py-3 pl-2.5">{slots.left}</div>}
         <input
           {...restProps}
           type={type}
-          className={cn(input())}
+          className={cn(
+            input({
+              slots: slotClass,
+            }),
+          )}
           autoComplete={autoComplete}
           readOnly={readOnly}
           disabled={disabled}
@@ -87,6 +112,7 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
           onFocus={handleFocus}
           onBlur={handleBlur}
         />
+        {slots?.right && <div className="py-3 pr-2.5">{slots.right}</div>}
       </div>
     )
   },

--- a/src/shared/ui/text-field/index.tsx
+++ b/src/shared/ui/text-field/index.tsx
@@ -1,6 +1,12 @@
-import { forwardRef, InputHTMLAttributes } from 'react'
+import {
+  forwardRef,
+  InputHTMLAttributes,
+  useImperativeHandle,
+  MouseEvent,
+  FocusEvent,
+} from 'react'
 
-import { cn } from 'shared/lib'
+import { cn, useFocus } from 'shared/lib'
 import {
   textField,
   input,
@@ -23,10 +29,38 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
       disabled = false,
       maxLength = 255,
       autoComplete = 'off',
+      onClick,
+      onFocus,
+      onBlur,
       ...restProps
     },
     ref,
   ) => {
+    const {
+      focused,
+      elementRef,
+      handleElementClick,
+      handleElementFocus,
+      handleElementBlur,
+    } = useFocus<HTMLInputElement>()
+
+    useImperativeHandle(ref, () => elementRef.current as HTMLInputElement)
+
+    const handleClick = (event: MouseEvent<HTMLInputElement>) => {
+      onClick?.(event)
+      handleElementClick()
+    }
+
+    const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
+      onFocus?.(event)
+      handleElementFocus()
+    }
+
+    const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+      onBlur?.(event)
+      handleElementBlur()
+    }
+
     return (
       <div
         className={cn(
@@ -34,10 +68,11 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
             fullWidth,
             error,
             disabled,
+            focused,
             className,
           }),
         )}
-        onClick={focus}
+        onClick={handleClick}
       >
         <input
           {...restProps}
@@ -47,7 +82,10 @@ export const TextField = forwardRef<HTMLInputElement, Props>(
           readOnly={readOnly}
           disabled={disabled}
           maxLength={maxLength}
-          ref={ref}
+          data-error={error}
+          ref={elementRef}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
         />
       </div>
     )

--- a/src/shared/ui/text-field/index.tsx
+++ b/src/shared/ui/text-field/index.tsx
@@ -1,0 +1,57 @@
+import { forwardRef, InputHTMLAttributes } from 'react'
+
+import { cn } from 'shared/lib'
+import {
+  textField,
+  input,
+  TextFieldVariants,
+} from 'shared/ui/text-field/variants'
+
+type Props = InputHTMLAttributes<HTMLInputElement> &
+  TextFieldVariants & {
+    error?: boolean
+  }
+
+export const TextField = forwardRef<HTMLInputElement, Props>(
+  (
+    {
+      type = 'text',
+      className,
+      fullWidth = false,
+      error = false,
+      readOnly = false,
+      disabled = false,
+      maxLength = 255,
+      autoComplete = 'off',
+      ...restProps
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        className={cn(
+          textField({
+            fullWidth,
+            error,
+            disabled,
+            className,
+          }),
+        )}
+        onClick={focus}
+      >
+        <input
+          {...restProps}
+          type={type}
+          className={cn(input())}
+          autoComplete={autoComplete}
+          readOnly={readOnly}
+          disabled={disabled}
+          maxLength={maxLength}
+          ref={ref}
+        />
+      </div>
+    )
+  },
+)
+
+TextField.displayName = 'TextField'

--- a/src/shared/ui/text-field/text-field.stories.tsx
+++ b/src/shared/ui/text-field/text-field.stories.tsx
@@ -85,7 +85,7 @@ const meta = {
     },
   },
   args: {
-    type: 'text',
+    type: 'number',
     placeholder: 'placeholder',
     fullWidth: false,
     error: false,

--- a/src/shared/ui/text-field/text-field.stories.tsx
+++ b/src/shared/ui/text-field/text-field.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { TextField } from '.'
+
+const meta = {
+  title: 'Component/TextField',
+  component: TextField,
+  argTypes: {
+    error: {
+      control: 'boolean',
+      description: 'Whether the text field has an error',
+    },
+    fullWidth: {
+      control: 'boolean',
+      description: 'Whether the text field should take up the full width',
+    },
+    readOnly: {
+      control: 'boolean',
+      description: 'Whether the text field is read-only',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the text field is disabled',
+    },
+  },
+  args: {
+    fullWidth: false,
+    disabled: false,
+  },
+} satisfies Meta<typeof TextField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {}

--- a/src/shared/ui/text-field/text-field.stories.tsx
+++ b/src/shared/ui/text-field/text-field.stories.tsx
@@ -85,7 +85,7 @@ const meta = {
     },
   },
   args: {
-    type: 'number',
+    type: 'text',
     placeholder: 'placeholder',
     fullWidth: false,
     error: false,

--- a/src/shared/ui/text-field/text-field.stories.tsx
+++ b/src/shared/ui/text-field/text-field.stories.tsx
@@ -1,35 +1,136 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { Slot } from 'shared/lib'
+
 import { TextField } from '.'
 
 const meta = {
   title: 'Component/TextField',
   component: TextField,
+  decorators: [
+    Story => (
+      <div className="flex w-[500px] justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    componentSubtitle:
+      'TextField is an interactive element that displays the user input.',
+  },
   argTypes: {
-    error: {
-      control: 'boolean',
-      description: 'Whether the text field has an error',
+    type: {
+      control: 'select',
+      options: ['text', 'password', 'email', 'number'],
+      description: 'The type of the input field',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    className: {
+      control: 'text',
+      description: 'The class name of the text field',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    placeholder: {
+      control: 'text',
+      description: 'The placeholder of the text field',
+      table: {
+        type: { summary: 'string' },
+      },
     },
     fullWidth: {
       control: 'boolean',
       description: 'Whether the text field should take up the full width',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    error: {
+      control: 'boolean',
+      description: 'Whether the text field has an error',
+      table: {
+        type: { summary: 'boolean' },
+      },
     },
     readOnly: {
       control: 'boolean',
       description: 'Whether the text field is read-only',
+      table: {
+        type: { summary: 'boolean' },
+      },
     },
     disabled: {
       control: 'boolean',
       description: 'Whether the text field is disabled',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    maxLength: {
+      control: 'number',
+      description: 'The maximum length of the text field',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    autoComplete: {
+      control: 'text',
+      description: 'The autocomplete attribute of the text field',
+      table: {
+        type: { summary: 'string' },
+      },
     },
   },
   args: {
+    type: 'text',
+    placeholder: 'placeholder',
     fullWidth: false,
+    error: false,
+    readOnly: false,
     disabled: false,
+    maxLength: 255,
+    autoComplete: 'off',
   },
 } satisfies Meta<typeof TextField>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Primary: Story = {}
+export const Default: Story = {}
+
+export const Error: Story = {
+  args: {
+    error: true,
+  },
+}
+
+export const ReadOnly: Story = {
+  args: {
+    readOnly: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
+// TODO: 아이콘으로 교체
+export const WithSlot: Story = {
+  args: {
+    children: (
+      <>
+        <Slot name="left">
+          <p>Left</p>
+        </Slot>
+        <Slot name="right">
+          <p>Right</p>
+        </Slot>
+      </>
+    ),
+  },
+}

--- a/src/shared/ui/text-field/variants.ts
+++ b/src/shared/ui/text-field/variants.ts
@@ -16,18 +16,23 @@ export const textField = cva(
         true: 'bg-gray-100 text-gray-500',
         false: '',
       },
+      focused: {
+        true: 'border-2',
+        false: '',
+      },
     },
 
     compoundVariants: [
       {
         error: false,
         disabled: false,
-        class: 'has-[:focus]:border-2 has-[:focus]:border-blue-800',
+        focused: true,
+        class: 'border-blue-800',
       },
       {
         error: true,
         disabled: false,
-        class: 'border-error has-[:focus]:border-2',
+        class: 'border-error',
       },
     ],
   },

--- a/src/shared/ui/text-field/variants.ts
+++ b/src/shared/ui/text-field/variants.ts
@@ -1,0 +1,49 @@
+import { cva, VariantProps } from 'class-variance-authority'
+
+export const textField = cva(
+  'body-medium flex h-12 w-[22.5rem] items-center gap-2 rounded-lg border border-gray-300 bg-white transition-all',
+  {
+    variants: {
+      fullWidth: {
+        true: 'w-full',
+        false: '',
+      },
+      error: {
+        true: 'border-error',
+        false: '',
+      },
+      disabled: {
+        true: 'bg-gray-100 text-gray-500',
+        false: '',
+      },
+    },
+
+    compoundVariants: [
+      {
+        error: false,
+        disabled: false,
+        class: 'has-[:focus]:border-2 has-[:focus]:border-blue-800',
+      },
+      {
+        error: true,
+        disabled: false,
+        class: 'border-error has-[:focus]:border-2',
+      },
+    ],
+  },
+)
+
+export const input = cva(
+  'peer h-full w-full bg-transparent px-2.5 py-3 placeholder:text-gray-500 disabled:pointer-events-none',
+  {
+    variants: {
+      slots: {
+        left: 'pl-0',
+        right: 'pr-0',
+        both: 'px-0',
+      },
+    },
+  },
+)
+
+export type TextFieldVariants = VariantProps<typeof textField>


### PR DESCRIPTION
### 🔎 What is this PR?

- 이슈 : [TextField](https://plus82.atlassian.net/browse/PD-40)

### 📝 Changes

- 요소의 focus 상태 관리를 위한 useFocus 훅 생성
  내부에 다른 요소를 함께 넣기 위해 `div` 안에 `input`이 존재하는데, `div` 내 `input`이 아닌 영역을 클릭하면 `input`이 `focus` 상태가 아니게 되어 스타일이 제대로 적용되지 않음. `div` 내 어느 영역을 클릭해도 동작하도록 `focus`를 상태로 따로 관리함.
- `Input` 컴포넌트의 내부 양쪽에 아이콘, 버튼과 같은 것들이 들어갈 수 있는 공간이 필요했고, 구현 방식을 고민하다가 `Slot`을 사용하는 것을 선택하게 됨. 한쪽에만 들어간다면 그냥 `children`으로 받으면 됐겠지만 그럴 수 없었고, `props`로 넘기기보다는 좀 더 깔끔하고 명료하게 작성할 수 있는 방식을 찾고 싶었음. `Slot`을 사용하는 방식이 상대적으로 깔끔하다고 느껴졌고, 외부에서 받아야 하는 요소가 몇 개든 좀 더 직관적으로 넘길 수 있을 것 같았음. [[참고한 글]](https://velog.io/@qkrdkwl9090/React%EC%97%90%EC%84%9C-Slot-%ED%8C%A8%ED%84%B4%EA%B3%BC-Coumpound-Component-%ED%8C%A8%ED%84%B4-%EC%82%AC%EC%9A%A9)
  아래와 같은 방식으로 컴포넌트 좌측, 우측에 값 또는 컴포넌트를 넣을 수 있음
```tsx
<TextField>
  <Slot name="left">
    <Icon />
  </Slot>
  <Slot name="right">
    <Button />
  </Slot>
</TextField>
``` 
- TextField 컴포넌트 및 스토리 작성