### PR TITLE
[Feature] Dropdown

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,3 +46,23 @@ button {
     @apply text-xs font-medium leading-4;
   }
 }
+
+.scrollbar {
+  overflow: auto;
+}
+
+.scrollbar::-webkit-scrollbar {
+  @apply h-3 w-3 bg-white;
+}
+
+.scrollbar::-webkit-scrollbar-thumb {
+  @apply rounded-full border border-solid border-transparent bg-gray-700 bg-clip-content;
+}
+
+.scrollbar::-webkit-scrollbar:vertical {
+  @apply border-0 border-l border-solid border-l-gray-300;
+}
+
+.scrollbar::-webkit-scrollbar:horizontal {
+  @apply border-0 border-t border-solid border-t-gray-300;
+}

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -1,1 +1,1 @@
-export { colors, fontSize } from './tokens'
+export { colors, fontSize, zIndex } from './tokens'

--- a/src/shared/config/tokens.ts
+++ b/src/shared/config/tokens.ts
@@ -36,4 +36,17 @@ export const fontSize = {
   xl: '1.5rem', // 24
   '2xl': '1.75rem', // 28
   '3xl': '2rem', // 32
-}
+} as const
+
+export const zIndex = {
+  deepdive: '-99999',
+  default: '1',
+  tooltip: '6000',
+  docked: '4',
+  dropdown: '7000',
+  modal: '9000',
+  overlay: '8000',
+  spinner: '9050',
+  sticky: '100',
+  snackbar: '10000',
+} as const

--- a/src/shared/lib/click-away.ts
+++ b/src/shared/lib/click-away.ts
@@ -1,0 +1,36 @@
+import type { Dispatch, RefObject, SetStateAction } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+
+type Props<T> = {
+  ref: RefObject<T>
+  callback?: (event: MouseEvent) => void
+}
+
+type ReturnType = [boolean, Dispatch<SetStateAction<boolean>>]
+
+export const useClickAway = <T extends HTMLElement>({
+  ref,
+  callback,
+}: Props<T>): ReturnType => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) {
+        setIsOpen(false)
+        callback?.(event)
+      }
+    },
+    [callback, ref],
+  )
+
+  useEffect(() => {
+    window.addEventListener('click', handleClick, true)
+
+    return () => {
+      window.removeEventListener('click', handleClick, true)
+    }
+  }, [handleClick, ref])
+
+  return [isOpen, setIsOpen]
+}

--- a/src/shared/lib/dropdown.ts
+++ b/src/shared/lib/dropdown.ts
@@ -1,0 +1,73 @@
+import type { KeyboardEvent, RefObject } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { useClickAway } from './click-away'
+import { useEscape } from './escape'
+import { isNilOrEmptyString } from './helper'
+
+type DropdownValue = string | number | null
+
+type Props = {
+  value?: DropdownValue
+}
+
+type ReturnType = {
+  isOpen: boolean
+  selectedValue: DropdownValue
+  dropdownRef: RefObject<HTMLDivElement>
+  open: () => void
+  close: () => void
+  toggleIsOpen: () => void
+  updateSelectedValue: (value: DropdownValue) => void
+  handleTriggerClick: () => void
+  handleTriggerKeyDown: (event: KeyboardEvent) => void
+}
+
+export const useDropdown = ({
+  value: externalValue,
+}: Props = {}): ReturnType => {
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const [selectedValue, setSelectedValue] = useState<DropdownValue>(
+    isNilOrEmptyString(externalValue) ? null : externalValue,
+  )
+
+  const [isOpen, setIsOpen] = useClickAway({ ref: dropdownRef })
+
+  const open = useCallback(() => setIsOpen(true), [setIsOpen])
+  const close = useCallback(() => setIsOpen(false), [setIsOpen])
+  const toggleIsOpen = () => setIsOpen(prevIsOpen => !prevIsOpen)
+
+  const handleEscapeKeyDown = useCallback(() => setIsOpen(false), [setIsOpen])
+
+  useEscape({ isOpen, onClose: handleEscapeKeyDown })
+
+  const updateSelectedValue = (selectedValueToBeUpdated: DropdownValue) =>
+    setSelectedValue(selectedValueToBeUpdated)
+
+  const handleTriggerClick = () => toggleIsOpen()
+
+  const handleTriggerKeyDown = (event: KeyboardEvent) => {
+    if (!event.defaultPrevented) {
+      if (event.key === 'Enter') {
+        toggleIsOpen()
+      }
+    }
+  }
+
+  useEffect(() => {
+    setSelectedValue(externalValue ?? null)
+  }, [externalValue])
+
+  return {
+    isOpen,
+    selectedValue,
+    dropdownRef,
+    open,
+    close,
+    toggleIsOpen,
+    updateSelectedValue,
+    handleTriggerClick,
+    handleTriggerKeyDown,
+  }
+}

--- a/src/shared/lib/escape.ts
+++ b/src/shared/lib/escape.ts
@@ -1,0 +1,27 @@
+import type { SyntheticEvent } from 'react'
+import { useEffect } from 'react'
+
+type Props = {
+  isOpen?: boolean
+  onClose?: (event: SyntheticEvent | Event | null) => void
+}
+
+export const useEscape = ({ isOpen, onClose }: Props) => {
+  useEffect(() => {
+    if (!isOpen) return undefined
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.defaultPrevented) {
+        if (event.key === 'Escape' || event.key === 'Esc') {
+          onClose?.(event)
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, onClose])
+}

--- a/src/shared/lib/helper.ts
+++ b/src/shared/lib/helper.ts
@@ -1,0 +1,7 @@
+import { isNil } from 'lodash-es'
+
+export const isEmptyString = (value: any): value is '' => value === ''
+
+export const isNilOrEmptyString = (
+  value: any,
+): value is null | undefined | '' => isNil(value) || isEmptyString(value)

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,3 +1,7 @@
-export { cn } from './classname'
 export { Slot, createSlot } from './slot'
+export { cn } from './classname'
+export { useClickAway } from './click-away'
+export { useDropdown } from './dropdown'
+export { useEscape } from './escape'
 export { useFocus } from './focus'
+export { isNilOrEmptyString, isEmptyString } from './helper'

--- a/src/shared/ui/dropdown/constants.ts
+++ b/src/shared/ui/dropdown/constants.ts
@@ -1,0 +1,4 @@
+// REM 기준
+export const ITEM_HEIGHT = {
+  DEFAULT: 3,
+} as const

--- a/src/shared/ui/dropdown/dropdown.stories.tsx
+++ b/src/shared/ui/dropdown/dropdown.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ReactNode } from 'react'
+import { useLayoutEffect } from 'react'
+
+import { cn, useDropdown } from 'shared/lib'
+
+import { Dropdown, DropdownRootProps } from './dropdown'
+import { wrapperOnlyForStory } from './variants'
+
+const meta = {
+  title: 'Component/Dropdown',
+  component: Dropdown,
+  parameters: {
+    componentSubtitle:
+      'Dropdown is a component that displays a list of options that the user can select.',
+    docs: {
+      description: {
+        component:
+          '- The following components can be used as Children \n' +
+          '- <Dropdown.Group> : You can group options together in a dropdown. \n' +
+          '- <Dropdown.Item> : You can create options to appear in the dropdown. \n',
+      },
+    },
+  },
+  args: {
+    displayLimit: 5,
+  },
+  argTypes: {
+    displayLimit: {
+      control: 'number',
+      description:
+        'Sets the number of items that can be displayed at once in the dropdown.',
+    },
+  },
+} satisfies Meta<typeof Dropdown>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+type DropdownStoryPropsType = DropdownRootProps & {
+  render: (
+    props: Pick<
+      ReturnType<typeof useDropdown>,
+      'selectedValue' | 'updateSelectedValue'
+    >,
+  ) => ReactNode
+}
+
+const DropdownStory = ({ render, ...restProps }: DropdownStoryPropsType) => {
+  const {
+    isOpen,
+    selectedValue,
+    dropdownRef,
+    open,
+    updateSelectedValue,
+    handleTriggerClick,
+    handleTriggerKeyDown,
+  } = useDropdown()
+
+  useLayoutEffect(() => {
+    open()
+  }, [open])
+
+  return (
+    <div className={cn(wrapperOnlyForStory())} ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={handleTriggerClick}
+        onKeyDown={handleTriggerKeyDown}
+      >
+        {selectedValue ?? 'Trigger'}
+      </button>
+      {isOpen && (
+        <Dropdown {...restProps}>
+          {render({ ...restProps, selectedValue, updateSelectedValue })}
+        </Dropdown>
+      )}
+    </div>
+  )
+}
+
+export const Default: Story = {
+  render: args => (
+    <DropdownStory
+      {...args}
+      render={() => (
+        <>
+          {Array.from({ length: 10 }, (_, index) => `Item ${index + 1}`).map(
+            value => (
+              <Dropdown.Item
+                key={value}
+                value={value}
+                onClick={() => console.log(value)}
+              >
+                {value}
+              </Dropdown.Item>
+            ),
+          )}
+        </>
+      )}
+    />
+  ),
+}
+
+export const Selectable: Story = {
+  render: args => (
+    <DropdownStory
+      {...args}
+      render={({ selectedValue, updateSelectedValue }) => (
+        <>
+          {Array.from({ length: 10 }, (_, index) => `Item ${index + 1}`).map(
+            value => (
+              <Dropdown.Item
+                key={value}
+                value={value}
+                onClick={() => updateSelectedValue(value)}
+                selected={value === selectedValue}
+              >
+                {value}
+              </Dropdown.Item>
+            ),
+          )}
+        </>
+      )}
+    />
+  ),
+}
+
+export const Grouping: Story = {
+  render: args => (
+    <DropdownStory
+      {...args}
+      render={() => (
+        <>
+          <Dropdown.Group>
+            <Dropdown.Item>Item 1</Dropdown.Item>
+            <Dropdown.Item selected>Item 2</Dropdown.Item>
+            <Dropdown.Item>Item 3</Dropdown.Item>
+          </Dropdown.Group>
+          <Dropdown.Group>
+            <Dropdown.Item>Item 3</Dropdown.Item>
+            <Dropdown.Item>Item 4</Dropdown.Item>
+            <Dropdown.Item>Item 6</Dropdown.Item>
+          </Dropdown.Group>
+          <Dropdown.Group>
+            <Dropdown.Item>Item 7</Dropdown.Item>
+            <Dropdown.Item>Item 8</Dropdown.Item>
+            <Dropdown.Item>Item 9</Dropdown.Item>
+          </Dropdown.Group>
+        </>
+      )}
+    />
+  ),
+}

--- a/src/shared/ui/dropdown/dropdown.stories.tsx
+++ b/src/shared/ui/dropdown/dropdown.stories.tsx
@@ -22,15 +22,26 @@ const meta = {
       },
     },
   },
-  args: {
-    displayLimit: 5,
-  },
   argTypes: {
     displayLimit: {
       control: 'number',
       description:
         'Sets the number of items that can be displayed at once in the dropdown.',
+      table: {
+        type: { summary: 'number' },
+      },
     },
+    role: {
+      control: 'text',
+      description: 'Sets the ARIA role for the dropdown.',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+  },
+  args: {
+    displayLimit: 5,
+    role: 'menu',
   },
 } satisfies Meta<typeof Dropdown>
 

--- a/src/shared/ui/dropdown/dropdown.tsx
+++ b/src/shared/ui/dropdown/dropdown.tsx
@@ -41,7 +41,7 @@ const DropdownRoot = forwardRef<HTMLDivElement, DropdownRootProps>(
         <ul
           className={cn(dropdown())}
           role={role}
-          style={{ height: `${dropdownHeight}rem` }}
+          style={{ maxHeight: `${dropdownHeight}rem` }}
           {...restProps}
         >
           {children}

--- a/src/shared/ui/dropdown/dropdown.tsx
+++ b/src/shared/ui/dropdown/dropdown.tsx
@@ -1,0 +1,104 @@
+import {
+  AriaRole,
+  LiHTMLAttributes,
+  MouseEvent,
+  PropsWithChildren,
+} from 'react'
+import { forwardRef } from 'react'
+
+import { colors } from 'shared/config'
+import { cn } from 'shared/lib'
+
+import { Icon } from '../icon'
+
+import { ITEM_HEIGHT } from './constants'
+import {
+  dropdownWrapper,
+  dropdownGroup,
+  dropdownItemContent,
+  dropdownItem,
+  dropdown,
+} from './variants'
+
+export type DropdownRootProps = PropsWithChildren<{
+  id?: string
+  className?: string
+  onClick?: (event?: MouseEvent) => void
+  displayLimit?: number
+  role?: AriaRole
+}>
+
+const DropdownRoot = forwardRef<HTMLDivElement, DropdownRootProps>(
+  (
+    { role = 'menu', className, displayLimit = 5, children, ...restProps },
+    ref,
+  ) => {
+    const itemHeight = ITEM_HEIGHT.DEFAULT
+    const dropdownHeight = displayLimit * itemHeight + itemHeight / 2
+
+    return (
+      <div className={cn(dropdownWrapper({ className }))} ref={ref}>
+        <ul
+          className={cn(dropdown())}
+          role={role}
+          style={{ height: `${dropdownHeight}rem` }}
+          {...restProps}
+        >
+          {children}
+        </ul>
+      </div>
+    )
+  },
+)
+
+DropdownRoot.displayName = 'Dropdown'
+
+type DropdownGroupProps = {
+  className?: string
+}
+
+const DropdownGroup = ({
+  className,
+  children,
+}: PropsWithChildren<DropdownGroupProps>) => (
+  <li className={cn(dropdownGroup({ className }))}>
+    <ul>{children}</ul>
+  </li>
+)
+
+export type DropdownItemProps = LiHTMLAttributes<HTMLLIElement> & {
+  selected?: boolean
+  role?: AriaRole
+}
+
+const DropdownItem = forwardRef<
+  HTMLLIElement,
+  PropsWithChildren<DropdownItemProps>
+>(
+  (
+    { children, className, selected = false, role = 'menuitem', ...restProps },
+    ref,
+  ) => {
+    return (
+      <li
+        role={role}
+        className={cn(dropdownItem({ className }))}
+        aria-selected={selected}
+        data-selected={selected}
+        {...restProps}
+        ref={ref}
+      >
+        <div className={cn(dropdownItemContent())}>
+          {children}
+          {selected && <Icon name="Check" color={colors.gray['700']} />}
+        </div>
+      </li>
+    )
+  },
+)
+DropdownItem.displayName = 'DropdownItem'
+
+export const Dropdown = Object.assign(DropdownRoot, {
+  Group: DropdownGroup,
+  Item: DropdownItem,
+})

--- a/src/shared/ui/dropdown/index.tsx
+++ b/src/shared/ui/dropdown/index.tsx
@@ -1,0 +1,1 @@
+export { Dropdown } from './dropdown'

--- a/src/shared/ui/dropdown/variants.ts
+++ b/src/shared/ui/dropdown/variants.ts
@@ -1,0 +1,19 @@
+import { cva } from 'class-variance-authority'
+
+export const dropdownWrapper = cva(
+  'absolute left-0 top-[calc(100%+6px)] z-dropdown w-full overflow-hidden rounded-lg border border-gray-300 bg-white',
+)
+
+export const dropdown = cva('scrollbar overflow-auto')
+
+export const dropdownGroup = cva('group')
+
+export const dropdownItem = cva(
+  'body-medium min-h-12 cursor-pointer p-3 leading-6 text-gray-900 hover:bg-gray-100 group-[:not(:last-child)]:last:border-b group-[:not(:last-child)]:last:border-b-gray-500 data-selected:bg-gray-100 not-last:border-b not-last:border-b-gray-300',
+)
+
+export const dropdownItemContent = cva('flex items-center justify-between')
+
+export const wrapperOnlyForStory = cva(
+  'relative flex h-[2rem] w-[200px] items-center justify-center',
+)

--- a/src/shared/ui/icon/assets/check.svg
+++ b/src/shared/ui/icon/assets/check.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M4 12L10 18L20 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/ui/icon/assets/index.ts
+++ b/src/shared/ui/icon/assets/index.ts
@@ -1,5 +1,6 @@
 import BookMarkOff from './bookmark-off.svg'
 import BookMarkOn from './bookmark-on.svg'
+import Check from './check.svg'
 import ChevronDown from './chevron-down.svg'
 import ChevronLeft from './chevron-left.svg'
 import ChevronRight from './chevron-right.svg'
@@ -17,6 +18,7 @@ import Search from './search.svg'
 export const IconComponent = {
   BookMarkOff,
   BookMarkOn,
+  Check,
   ChevronDown,
   ChevronLeft,
   ChevronRight,

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,3 @@
+export { Button } from './button'
+export { Icon } from './icon'
+export { TextField } from './text-field'

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,3 +1,4 @@
 export { Button } from './button'
 export { Icon } from './icon'
 export { TextField } from './text-field'
+export { Dropdown } from './dropdown'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
-import type { Config } from 'tailwindcss'
+import { Config } from 'tailwindcss'
 
-import { colors, fontSize } from './src/shared/config'
+import { colors, fontSize, zIndex } from './src/shared/config'
 
 const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}', './app/**/*.{js,ts,jsx,tsx,mdx}'],
@@ -11,8 +11,10 @@ const config: Config = {
       },
       colors,
       fontSize,
+      zIndex,
     },
   },
   plugins: [],
 }
+
 export default config

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,14 @@
 import { Config } from 'tailwindcss'
+import plugin from 'tailwindcss/plugin'
 
 import { colors, fontSize, zIndex } from './src/shared/config'
 
 const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}', './app/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
+    data: {
+      selected: 'selected~=true',
+    },
     extend: {
       fontFamily: {
         'spoqa-han-sans-neo': ['var(--font-spoqa-han-sans-neo)'],
@@ -14,7 +18,11 @@ const config: Config = {
       zIndex,
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addVariant }) {
+      addVariant('not-last', '&:not(:last-child)')
+    }),
+  ],
 }
 
 export default config


### PR DESCRIPTION
### 🔎 What is this PR?

- 이슈 : [Dropdown](https://plus82.atlassian.net/browse/PD-54)

### 📝 Changes

- Dropdown 컴포넌트 작성
  - 메뉴 리스트에서 옵션들을 묶어 그룹을 생성할 수 있음
  - Dropdown과 함께 사용할 수 있는 useDropdown 훅 생성
    (선택된 값 관리, 외부 클릭 및 ESC 키 입력 시 닫힘, 방향키로 옵션 선택 등 기능 추가 필요)

### 📋 Comment

- [Add variant](https://tailwindcss.com/docs/plugins#adding-variants) : 원하는 Selector가 없을 경우 생성 가능
```tsx
const config = {
  plugins: [
    plugin(function ({ addVariant }) {
      addVariant('not-last', '&:not(:last-child)')
    }),
  ],
}
```

- [Data attribute](https://tailwindcss.com/docs/hover-focus-and-other-states#data-attributes) : `config`에 추가하거나 `data-[]`와 같은 방식으로 사용 가능

- 같은 세그먼트 내부에서는 상대 경로로 가져오기

<img width="679" alt="image" src="https://github.com/user-attachments/assets/29dfe78d-e103-4062-a4fe-b6c9932dfa3c">

스토리북에서 위와 같은 에러가 발생함

```tsx
// shared/ui/dropdown/dropdown.tsx
import { Icon } from 'shared/ui'

// shared/ui/index.ts
export { Button } from './button'
export { Icon } from './icon'
export { TextField } from './text-field'
export { Dropdown } from './dropdown'
```

아이콘을 `shared/ui` 경로에서 가져오고 있었고, `Dropdown`을 여기서 내보내고 있어서 문제였음

```tsx
// shared/ui/dropdown/dropdown.tsx
import { Icon } from '..icon'
```

이렇게 상대 경로로 사용하면 됨

- hook, util 함수 등의 적절한 위치에 대해 추가적으로 고민 필요