### PR TITLE
[Fix] 이력서 생성 시 유저 이미지를 기본으로 지정

### DIFF
--- a/src/entities/resume/model/resume.ts
+++ b/src/entities/resume/model/resume.ts
@@ -23,7 +23,7 @@ export type Resume = {
   residenceCountryNameEn: string
   createdAt: string
   updatedAt: string
-  profileImagePath?: string
+  profileImagePath?: string | null
   filePath: string | null
   fileName: string | null
 }

--- a/src/entities/user/model/user.ts
+++ b/src/entities/user/model/user.ts
@@ -10,5 +10,5 @@ export type User = {
   countryCode: string
   countryCallingCode: string
   flag: string
-  profileImagePath: string
+  profileImagePath: string | null
 }

--- a/src/features/resume-form/ui/resume-form.tsx
+++ b/src/features/resume-form/ui/resume-form.tsx
@@ -23,16 +23,17 @@ import {
 import * as rules from '../model/rules'
 
 type Props = {
+  userProfileImage?: string | null
   resume?: Resume
   submit: (data: ResumeDTO) => Promise<ServerError | undefined>
 }
 
-export const ResumeForm = ({ resume, submit }: Props) => {
+export const ResumeForm = ({ userProfileImage, resume, submit }: Props) => {
   const router = useRouter()
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(
-    resume?.profileImagePath ?? null,
+    resume?.profileImagePath ?? userProfileImage ?? null,
   )
 
   const form = useForm<ResumeFormValues>({

--- a/src/pages/my-page/ui/user-image.tsx
+++ b/src/pages/my-page/ui/user-image.tsx
@@ -11,7 +11,7 @@ import { isNilOrEmptyString } from 'shared/lib'
 import { Button, Icon, Image } from 'shared/ui'
 
 type Props = {
-  src: string
+  src: string | null
   alt: string
 }
 
@@ -50,7 +50,7 @@ export const UserImage = ({ src, alt }: Props) => {
     <div className="flex flex-col items-center gap-3">
       <div>
         <Image
-          src={src}
+          src={src ?? ''}
           alt={alt}
           className="h-[110px] w-[110px] rounded-full"
           fallback={

--- a/src/pages/my-page/ui/user-profile.tsx
+++ b/src/pages/my-page/ui/user-profile.tsx
@@ -10,7 +10,7 @@ export const UserProfile = async () => {
   return (
     <div className="mb-10 flex gap-6 border-b border-gray-300 pb-4">
       <UserImage
-        src={user.profileImagePath}
+        src={user?.profileImagePath}
         alt={`${user.firstName} ${user.lastName} profile image`}
       />
       <div>

--- a/src/pages/resume/ui/create-resume-page.tsx
+++ b/src/pages/resume/ui/create-resume-page.tsx
@@ -1,6 +1,14 @@
 import { createResume } from 'entities/resume'
+import { getUserMe } from 'entities/user'
 import { ResumeForm } from 'features/resume-form'
 
-export const CreateResumePage = () => {
-  return <ResumeForm submit={createResume} />
+export const CreateResumePage = async () => {
+  const user = await getUserMe()
+
+  return (
+    <ResumeForm
+      userProfileImage={user.profileImagePath}
+      submit={createResume}
+    />
+  )
 }


### PR DESCRIPTION
### 🔎 What is this PR?

- 이슈 : [Mypage > Resume > Creat Resume | 프로필 사진이 있을 때 이력서 생성하는 중에 화면에 보이지 않음](https://plus82.atlassian.net/browse/PD-193)

### 📝 Changes

- 이력서 생성 시 유저 이미지를 기본 preview 이미지로 설정해서 보여줌
  폼에 이미지를 넣지는 않음 (이미지를 보내지 않고, 유저의 프로필 이미지가 존재하는 경우 백엔드에서 기본으로 값을 넣어줌)